### PR TITLE
Ms initial prompts

### DIFF
--- a/SAVE_WORK.md
+++ b/SAVE_WORK.md
@@ -1,30 +1,53 @@
-# How to Save Work (Commit & Push)
+# 🚀 Cursor Git Commands for Prompt Library
 
-You can save your work (stage, commit, and push changes) using either manual git commands or the provided script.
-
-## Option 1: Manual Git Commands
-1. Stage all changes:
-   ```sh
-   git add .
-   ```
-2. Commit with a descriptive message:
-   ```sh
-   git commit -m "Your descriptive message"
-   ```
-3. Push to the remote repository:
-   ```sh
-   git push
-   ```
-
-## Option 2: Use the Script (save-work.sh)
-1. Make sure you have bash (WSL, Git Bash, or similar).
-2. In your project root, run:
-   ```sh
-   ./save-work.sh "Your descriptive message"
-   ```
-   - If you omit the message, the script will prompt you for one.
+Use these commands inside Cursor's agent window to automate your workflow.
 
 ---
 
-**Shortcut:**
-Just tell the assistant: `save work` — and these steps will be performed for you automatically! 
+### 🆕 Start New Feature Branch
+```
+start "your-feature-name"
+```
+Creates and checks out a new feature branch.
+
+---
+
+### 💾 Save Your Work
+```
+save "short commit message"
+```
+Adds and commits all changes, then pushes to remote.
+
+---
+
+### 🔁 Create Pull Request
+```
+pr "Short PR summary title"
+```
+Generates the GitHub pull request link for your branch.
+
+---
+
+### 🔍 Check Current Git Status
+```
+check
+```
+Shows current branch and working directory status.
+
+---
+
+### 🔄 Sync with Main
+```
+sync
+```
+Pulls the latest changes from `main` before starting a new branch.
+
+---
+
+### ⚙️ Example Workflow
+```bash
+start "add-invoice-generator"
+# (do your changes)
+save "added initial invoice prompt"
+pr "Add invoice prompt to finance tools"
+```

--- a/prompts/project_management/meeting_minutes/from_jira/record_decision_from_jira_task_in_confluence_meeting_minutes.md
+++ b/prompts/project_management/meeting_minutes/from_jira/record_decision_from_jira_task_in_confluence_meeting_minutes.md
@@ -1,0 +1,91 @@
+# Record decision from Jira Task in Confluence meeting minutes
+
+---
+name: "Record decision from Jira Task in Confluence meeting minutes"
+category: "project_management/meeting_minutes/from_jira"
+description: "Records /decision made in a Jira Task comments as an out of band meeting minute in Confluence so that the decision is traceable"
+version: 1.0
+author: "Mathieu Schneider"
+compatible_llms: [claude]
+compatible_interfaces: [ui]
+inputs: [JIRA_TICKET_KEY, CONFLUENCE_PAGE_URL]
+outputs: []
+chaining_compatible: false
+---
+
+## How to Use This Prompt
+
+### Quick Start Guide
+1. **Prepare Your Input**: Create/publish the Confluence "out of band" meeting minutes and copy the Confluence page URL
+2. **Set Parameters**: Copy the Jira issue URL
+3. **Run the Prompt**: Review Claude's output, refine, then instruct Claude to publish
+4. **Review & Process**: Review new Confluence minutes page, manually clean up as need 
+
+### Video Tutorial
+📹 **Screen Recording**: [How to Use Record decision from Jira Task in Confluence meeting minutes](N/A)
+
+### Step-by-Step Instructions
+1. **Input Requirements**:
+   Jira issue should have a conversation within the comments that results in action_item or decision that needs to be tracked in Confluence
+   
+2. **Expected Output**:
+   Published Confluence Out of Band meeting minutes 
+and
+Jira comment with link back to page showing decision etc 
+
+3. **Best Practices**:
+   Create the Confluence page and set it to restricted, then publish, edit and one complete, remove restrictions
+
+### Common Use Cases
+Jira issue conversation leads to action item or decision that needs to be tracked. 
+Example, customer approves new or modified work
+
+---
+
+## prompt
+
+I need to document a project decision that was made in Jira comments as a formal Confluence decision record.
+
+**Jira Ticket**: {{JIRA_TICKET_KEY}}
+**Confluence Template Page**: {{CONFLUENCE_PAGE_URL}}
+
+Please:
+1. Analyze the conversation/decision in the Jira ticket comments
+2. Fill out the Confluence template page with:
+   - Participants (from Jira commenters)
+   - Context/background of the decision
+   - Discussion topics and key points
+   - Final decisions made with rationale
+   - Action items and owners
+   - References back to Jira and other documentation
+3. **🚨 CRITICAL: PROVIDE PREVIEW FOR REVIEW BEFORE PUBLISHING 🚨**
+   - Show me the completed Confluence content for approval
+   - Show me the proposed Jira comment for review
+   - Wait for my explicit approval before publishing anything
+4. Only after approval: Add cross-reference comment to Jira and publish Confluence updates
+
+**⚠️ IMPORTANT: Do not publish or update anything until I have reviewed and approved the content.**
+
+This creates bi-directional linking between our project tracking (Jira) and decision documentation (Confluence).
+
+<!-- END PROMPT -->
+
+## Example Usage
+```
+
+```
+
+## Best Practices
+
+
+## Common Pitfalls to Avoid
+
+
+## Adaptation Tips
+
+
+---
+Version: 1.0  
+Last Updated: 2025-08-11  
+Compatible With:   
+Recommended Use: 

--- a/prompts/project_management/meeting_minutes/from_transcripts/meeting_minutes_from_transcript_-_chatgpt.md
+++ b/prompts/project_management/meeting_minutes/from_transcripts/meeting_minutes_from_transcript_-_chatgpt.md
@@ -3,7 +3,7 @@
 ---
 name: "Meeting Minutes from Transcript - ChatGPT"
 category: "project_management/meeting_minutes"
-description: "Uses Gemini meeting transcript and converts to Confluence based structure format.
+description: "Uses Gemini meeting transcript and converts to Confluence based structure format."
 version: 1.0
 author: "Ajay Raman"
 compatible_llms: [chatgpt]


### PR DESCRIPTION
## ✅ Summary
Added new prompt for recording decisions from Jira tasks in Confluence meeting minutes. This prompt helps project managers and team leads efficiently document key decisions made during meetings by extracting information from Jira tasks and formatting it appropriately for Confluence meeting minutes.

## ✅ Prompt Metadata Validation
- [x] I have run `python scripts/validate_metadata.py`
- [x] All prompts have valid metadata per the schema

## ✅ Contribution Details
- New prompts added:
  - `prompts/project_management/meeting_minutes/from_jira/record_decision_from_jira_task_in_confluence_meeting_minutes.md` - Added comprehensive prompt for converting Jira task decisions into Confluence meeting minutes format
- Changes to existing prompts:
  - No changes to existing prompts

## ✅ Additional Notes
This prompt is part of Mathieu Schneider's initial prompts collection and integrates with existing project management workflows. It follows the established prompt template structure and includes proper metadata validation. The prompt helps bridge the gap between Jira task management and Confluence documentation, improving team collaboration and decision tracking.